### PR TITLE
remove references to .gel.zone URLs from docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ENV PYTHONUNBUFFERED 1
 ENV CIPAPI_SWAGGER_FORCE_HTTPS False
 ADD . /cip_api_tests
 
-RUN pip install --upgrade pip==9.0.3 && pip install .[test] --index-url=https://pypi.gel.zone/genomics/dev
+RUN pip install --upgrade pip==9.0.3 && pip install .[test]


### PR DESCRIPTION
This should not be needed once GelReportModels is published in pypi.org